### PR TITLE
appveyor.yml: Fix gcc issue on go test -race ./...

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,9 @@ branches:
 
 environment:
   GOPATH: c:\gopath
-  PATH: '%GOPATH%\bin;%PATH%'
+  PATH: '%GOPATH%\bin;%PATH%;C:\msys64\mingw64\bin'
+  matrix:
+    - TARGET: x86_64-pc-windows-gnu
 
 stack: go 1.10
 


### PR DESCRIPTION
Update appveyor.yml to use gcc for `go test -race ./...`