### PR TITLE
gpython: use peterh/liner@v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
    - go: master
      env:
        - TAGS="-tags travis"
+       - GO111MODULE=on
 
 script:
  - go install -v $TAGS ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
 module github.com/go-python/gpython
 
-require (
-	github.com/mattn/go-runewidth v0.0.3 // indirect
-	github.com/peterh/liner v0.0.0-20180619022028-8c1271fcf47f
-)
+require github.com/peterh/liner v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
+github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=


### PR DESCRIPTION
This CL bumps `go.mod` to use peterh/liner@v1.1.0.

Also really test Go modules by enabling `GO111MODULE=on`, only for `master`.