### PR TITLE
py: Fix errors are suppressed in generator comprehensions

### DIFF
--- a/py/sequence.go
+++ b/py/sequence.go
@@ -93,9 +93,12 @@ func Iterate(obj Object, fn func(Object) bool) error {
 			return err
 		}
 		for {
-			item, finished := Next(iterator)
-			if finished != nil {
+			item, err := Next(iterator)
+			if err == StopIteration {
 				break
+			}
+			if err != nil {
+				return err
 			}
 			if fn(item) {
 				break

--- a/vm/tests/generators.py
+++ b/vm/tests/generators.py
@@ -25,6 +25,14 @@ def g2():
         yield i
 assert tuple(g2()) == (0,1,2,3,4)
 
+doc="generator 3"
+ok = False
+try:
+    list(ax for x in range(10))
+except NameError:
+    ok = True
+assert ok, "NameError not raised"
+
 doc="yield from"
 def g3():
     yield "potato"


### PR DESCRIPTION
Sequence.Iterate does not handle exceptions.
Iterate() should return error except StopIteration.

Fixes: https://github.com/go-python/gpython/issues/32