### PR TITLE
fix: ~/.gpyhistory: no such file or directory

### DIFF
--- a/repl/cli/cli.go
+++ b/repl/cli/cli.go
@@ -126,7 +126,9 @@ func RunREPL() {
 	defer rl.Close()
 	err := rl.ReadHistory()
 	if err != nil {
-		fmt.Printf("Failed to open history: %v\n", err)
+		if !os.IsNotExist(err) {
+			fmt.Printf("Failed to open history: %v\n", err)
+		}
 	}
 
 	for {


### PR DESCRIPTION
Now when the ~/.gpyhistory file does not exist, do not show the error
message in the repl, as long as this does not disrupt the experience in the repl.

Fixes go-python/gpython#62.