### PR TITLE
Fix comments in REPL - fixes #78

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -82,9 +82,13 @@ func (r *REPL) Run(line string) {
 		// FIXME detect EOF properly!
 		errText := err.Error()
 		if strings.Contains(errText, "unexpected EOF while parsing") || strings.Contains(errText, "EOF while scanning triple-quoted string literal") {
-			r.continuation = true
-			r.previous += string(line) + "\n"
-			r.term.SetPrompt(ContinuationPrompt)
+			stripped := strings.TrimSpace(toCompile)
+			isComment := len(stripped) > 0 && stripped[0] == '#'
+			if !isComment {
+				r.continuation = true
+				r.previous += string(line) + "\n"
+				r.term.SetPrompt(ContinuationPrompt)
+			}
 			return
 		}
 	}

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -67,6 +67,14 @@ func TestREPL(t *testing.T) {
 
 	r.Run("if")
 	rt.assert(t, "compileError", NormalPrompt, "Compile error: \n  File \"<string>\", line 1, offset 2\n    if\n\n\nSyntaxError: 'invalid syntax'")
+
+	// test comments in the REPL work properly
+	r.Run("# this is a comment")
+	rt.assert(t, "comment", NormalPrompt, "")
+	r.Run("a = 42")
+	rt.assert(t, "comment continuation", NormalPrompt, "")
+	r.Run("a")
+	rt.assert(t, "comment check", NormalPrompt, "42")
 }
 
 func TestCompleter(t *testing.T) {


### PR DESCRIPTION
Before this change, entering a comment in the REPL caused the REPL to
read the comment indefinitely effectively breaking it.

After this change the behaviour should be exactly the same as python3/