### PR TITLE
Fix "end" option in print func

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -176,10 +176,10 @@ flush: whether to forcibly flush the stream.`
 
 func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Object, error) {
 	var (
-		sepObj py.Object = py.String(" ")
+	  	sepObj py.Object = py.String(" ")
 		endObj py.Object = py.String("\n")
 		file   py.Object = py.MustGetModule("sys").Globals["stdout"]
-		flush  py.Object
+	 	flush  py.Object
 	)
 	kwlist := []string{"sep", "end", "file", "flush"}
 	err := py.ParseTupleAndKeywords(nil, kwargs, "|ssOO:print", kwlist, &sepObj, &endObj, &file, &flush)
@@ -187,6 +187,10 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 		return nil, err
 	}
 	sep := sepObj.(py.String)
+
+	if kwargs["end"] != nil {
+		endObj = kwargs["end"]
+	}
 	end := endObj.(py.String)
 
 	write, err := py.GetAttrString(file, "write")
@@ -195,7 +199,7 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 	}
 
 	for i, v := range args {
-		v, err := py.Str(v)
+	 	v, err := py.Str(v)
 		if err != nil {
 			return nil, err
 		}
@@ -209,7 +213,7 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 			_, err = py.Call(write, py.Tuple{sep}, nil)
 			if err != nil {
 				return nil, err
-			}
+	 		}
 		}
 	}
 

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -176,10 +176,10 @@ flush: whether to forcibly flush the stream.`
 
 func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Object, error) {
 	var (
-	  	sepObj py.Object = py.String(" ")
+		sepObj py.Object = py.String(" ")
 		endObj py.Object = py.String("\n")
 		file   py.Object = py.MustGetModule("sys").Globals["stdout"]
-	 	flush  py.Object
+		flush  py.Object
 	)
 	kwlist := []string{"sep", "end", "file", "flush"}
 	err := py.ParseTupleAndKeywords(nil, kwargs, "|ssOO:print", kwlist, &sepObj, &endObj, &file, &flush)
@@ -199,7 +199,7 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 	}
 
 	for i, v := range args {
-	 	v, err := py.Str(v)
+		v, err := py.Str(v)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,7 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 			_, err = py.Call(write, py.Tuple{sep}, nil)
 			if err != nil {
 				return nil, err
-	 		}
+			}
 		}
 	}
 

--- a/builtin/tests/builtin.py
+++ b/builtin/tests/builtin.py
@@ -309,6 +309,12 @@ with open("testfile", "w") as f:
 with open("testfile", "r") as f:
     assert f.read() == "1,2,3,\n"
 
+with open("testfile", "w") as f:
+    print("hello",end="123", file=f)
+
+with open("testfile", "r") as f:
+    assert f.read() == "hello123"
+    
 doc="round"
 assert round(1.1) == 1.0
 

--- a/builtin/tests/builtin.py
+++ b/builtin/tests/builtin.py
@@ -310,7 +310,7 @@ with open("testfile", "r") as f:
     assert f.read() == "1,2,3,\n"
 
 with open("testfile", "w") as f:
-    print("hello",end="123", file=f)
+    print("hello",sep="",end="123", file=f)
 
 with open("testfile", "r") as f:
     assert f.read() == "hello123"


### PR DESCRIPTION
line 190 to 193.
I tried to apply the end option to the print function.
Added code performed when "end" value of parameter "kwargs" is not "nil".