### PR TITLE
Fixed "print function's "end" option error in CPython"

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -186,6 +186,12 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 	if err != nil {
 		return nil, err
 	}
+
+	if kwargs["sep"] != nil {
+		sepObj = kwargs["sep"]
+	} else {
+		sepObj = py.String(" ")
+	}
 	sep := sepObj.(py.String)
 
 	if kwargs["end"] != nil {

--- a/builtin/tests/builtin.py
+++ b/builtin/tests/builtin.py
@@ -282,6 +282,12 @@ except TypeError as e:
 assert ok, "TypeError not raised"
 
 try:
+    print("hello","gpython", end="123\n")
+except TypeError as e:
+    ok = True
+assert ok, "TypeError not raised"
+
+try:
     print("hello", sep=" ", end=1)
 except TypeError as e:
     #if e.args[0] != "end must be None or a string, not int":


### PR DESCRIPTION
The following code writes different string to the stream than in CPython:
```
print(1,2,3, end="||\n")
```

I fixed that bug by modifying the code
resolved: #93 