### PR TITLE
Revert "Fix "end" option in print func"

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -187,10 +187,6 @@ func builtin_print(self py.Object, args py.Tuple, kwargs py.StringDict) (py.Obje
 		return nil, err
 	}
 	sep := sepObj.(py.String)
-
-	if kwargs["end"] != nil {
-		endObj = kwargs["end"]
-	}
 	end := endObj.(py.String)
 
 	write, err := py.GetAttrString(file, "write")

--- a/builtin/tests/builtin.py
+++ b/builtin/tests/builtin.py
@@ -309,12 +309,6 @@ with open("testfile", "w") as f:
 with open("testfile", "r") as f:
     assert f.read() == "1,2,3,\n"
 
-with open("testfile", "w") as f:
-    print("hello",sep="",end="123", file=f)
-
-with open("testfile", "r") as f:
-    assert f.read() == "hello123"
-    
 doc="round"
 assert round(1.1) == 1.0
 


### PR DESCRIPTION
Reverts go-python/gpython#90

Sorry guys, I didn't review the patch #90 well.
The patch was not the proper approach.
