### PR TITLE
expose Token, Value, TokenToName and Pos on LexToken

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -330,6 +330,15 @@ func (lt *LexToken) String() string {
 	return fmt.Sprintf("%q (%d) = %T{%v} %d:%d", name, lt.token, lt.value, lt.value, lt.pos.Lineno, lt.pos.ColOffset)
 }
 
+// TokenToName returns the string name of a given token
+func (lt *LexToken) TokenToName() string {
+        name, ok := tokenToString[lt.token]
+        if !ok {
+                return ""
+        }
+        return name
+}
+
 // Token returns the int value of this token
 func (lt *LexToken) Token() int {
 	return lt.token


### PR DESCRIPTION
I am using your library to write a custom parser, and thus only depend on the lex functionality.  While writing it, I found it useful to be able to access these values.  Tossing it up here to see if you agree.  thanks for writing such a new library!