### PR TITLE
Adding missing __len__ method to dict objects

### DIFF
--- a/py/dict.go
+++ b/py/dict.go
@@ -114,6 +114,10 @@ func (a StringDict) M__str__() (Object, error) {
 	return a.M__repr__()
 }
 
+func (a StringDict) M__len__() (Object, error) {
+	return Int(len(a)), nil
+}
+
 func (a StringDict) M__repr__() (Object, error) {
 	var out bytes.Buffer
 	out.WriteRune('{')

--- a/py/tests/dict.py
+++ b/py/tests/dict.py
@@ -54,4 +54,9 @@ assert a.__ne__({}) == True
 assert a.__eq__({'a': 'b'}) == True
 assert a.__ne__({'a': 'b'}) == False
 
+doc="__len__"
+a = {"a": "1", "b": "2"}
+assert a.__len__() == 2
+assert len(a) == 2
+
 doc="finished"


### PR DESCRIPTION
Old behavior:

len({"a" : 1, "b" : 2})
```
TypeError: "object of type 'dict' has no len()"
```

New behavior returns the number of elements in the dict