### PR TITLE
py: int() default to decimal

### DIFF
--- a/py/int.go
+++ b/py/int.go
@@ -55,7 +55,7 @@ func (o Int) Type() *Type {
 func IntNew(metatype *Type, args Tuple, kwargs StringDict) (Object, error) {
 	var xObj Object = Int(0)
 	var baseObj Object
-	base := 0
+	base := 10
 	err := ParseTupleAndKeywords(args, kwargs, "|OO:int", []string{"x", "base"}, &xObj, &baseObj)
 	if err != nil {
 		return nil, err

--- a/py/tests/int.py
+++ b/py/tests/int.py
@@ -103,6 +103,7 @@ assert int("	100000	", 0) == tenE5
 
 doc="sigils"
 assert int("7") == 7
+assert int("07") == 7
 assert int("07", 10) == 7
 
 assert int("F", 16) == 15


### PR DESCRIPTION
https://docs.python.org/3.4/library/functions.html#int

> int(x, base=10)

If base=0, an exception will be thrown when executing `int("07")`