### PR TITLE
all: fix iterable object, implement `filter`, `map`, `oct` and optimise `hex`

### DIFF
--- a/py/arithmetic.go
+++ b/py/arithmetic.go
@@ -147,24 +147,6 @@ func MakeFloat(a Object) (Object, error) {
 	return nil, ExceptionNewf(TypeError, "unsupported operand type(s) for float: '%s'", a.Type().Name)
 }
 
-// Iter the python Object returning an Object
-//
-// Will raise TypeError if Iter can't be run on this object
-func Iter(a Object) (Object, error) {
-
-	if A, ok := a.(I__iter__); ok {
-		res, err := A.M__iter__()
-		if err != nil {
-			return nil, err
-		}
-		if res != NotImplemented {
-			return res, nil
-		}
-	}
-
-	return nil, ExceptionNewf(TypeError, "unsupported operand type(s) for iter: '%s'", a.Type().Name)
-}
-
 // Add two python objects together returning an Object
 //
 // Will raise TypeError if can't be add can't be run on these objects

--- a/py/dict.go
+++ b/py/dict.go
@@ -36,7 +36,7 @@ func init() {
 			return nil, err
 		}
 		sMap := self.(StringDict)
-		o := make([]Object, 0, len(sMap))
+		o := make(Tuple, 0, len(sMap))
 		for k, v := range sMap {
 			o = append(o, Tuple{String(k), v})
 		}
@@ -49,7 +49,7 @@ func init() {
 			return nil, err
 		}
 		sMap := self.(StringDict)
-		o := make([]Object, 0, len(sMap))
+		o := make(Tuple, 0, len(sMap))
 		for k := range sMap {
 			o = append(o, String(k))
 		}
@@ -62,7 +62,7 @@ func init() {
 			return nil, err
 		}
 		sMap := self.(StringDict)
-		o := make([]Object, 0, len(sMap))
+		o := make(Tuple, 0, len(sMap))
 		for _, v := range sMap {
 			o = append(o, v)
 		}
@@ -204,7 +204,7 @@ func (a StringDict) M__repr__() (Object, error) {
 
 // Returns a list of keys from the dict
 func (d StringDict) M__iter__() (Object, error) {
-	o := make([]Object, 0, len(d))
+	o := make(Tuple, 0, len(d))
 	for k := range d {
 		o = append(o, String(k))
 	}

--- a/py/exception.go
+++ b/py/exception.go
@@ -336,6 +336,8 @@ func ExceptionGivenMatches(err, exc Object) bool {
 func IsException(exception *Type, r interface{}) bool {
 	var t *Type
 	switch ex := r.(type) {
+	case ExceptionInfo:
+		t = ex.Type
 	case *Exception:
 		t = ex.Type()
 	case *Type:

--- a/py/filter.go
+++ b/py/filter.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package py
+
+// A python Filter object
+type Filter struct {
+	it  Object
+	fun Object
+}
+
+var FilterType = NewTypeX("filter", `filter(function or None, iterable) --> filter object
+
+Return an iterator yielding those items of iterable for which function(item)
+is true. If function is None, return the items that are true.`,
+	FilterTypeNew, nil)
+
+// Type of this object
+func (f *Filter) Type() *Type {
+	return FilterType
+}
+
+// FilterTypeNew
+func FilterTypeNew(metatype *Type, args Tuple, kwargs StringDict) (res Object, err error) {
+	var fun, seq Object
+	var it Object
+	err = UnpackTuple(args, kwargs, "filter", 2, 2, &fun, &seq)
+	if err != nil {
+		return nil, err
+	}
+	it, err = Iter(seq)
+	if err != nil {
+		return nil, err
+	}
+	return &Filter{it: it, fun: fun}, nil
+}
+
+func (f *Filter) M__iter__() (Object, error) {
+	return f, nil
+}
+
+func (f *Filter) M__next__() (Object, error) {
+	var ok bool
+	for {
+		item, err := Next(f.it)
+		if err != nil {
+			return nil, err
+		}
+		// if (lz->func == Py_None || lz->func == (PyObject *)&PyBool_Type)
+		if _, _ok := f.fun.(Bool); _ok || f.fun == None {
+			ok, err = ObjectIsTrue(item)
+		} else {
+			var good Object
+			good, err = Call(f.fun, Tuple{item}, nil)
+			if err != nil {
+				return nil, err
+			}
+			ok, err = ObjectIsTrue(good)
+		}
+		if ok {
+			return item, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// Check interface is satisfied
+var _ I__iter__ = (*Filter)(nil)
+var _ I__next__ = (*Filter)(nil)

--- a/py/gen.go
+++ b/py/gen.go
@@ -45,7 +45,6 @@ var data = Data{
 		{Name: "complex", Title: "MakeComplex", Operator: "complex", Unary: true, Conversion: "Complex"},
 		{Name: "int", Title: "MakeInt", Operator: "int", Unary: true, Conversion: "Int"},
 		{Name: "float", Title: "MakeFloat", Operator: "float", Unary: true, Conversion: "Float"},
-		{Name: "iter", Title: "Iter", Operator: "iter", Unary: true},
 	},
 	BinaryOps: Ops{
 		{Name: "add", Title: "Add", Operator: "+", Binary: true},

--- a/py/internal.go
+++ b/py/internal.go
@@ -430,3 +430,20 @@ func ReprAsString(self Object) (string, error) {
 	}
 	return string(str), nil
 }
+
+// Returns an iterator object
+//
+// Call __Iter__ Returns an iterator object
+//
+// If object is sequence object, create an iterator
+func Iter(self Object) (res Object, err error) {
+	if I, ok := self.(I__iter__); ok {
+		return I.M__iter__()
+	} else if res, ok, err = TypeCall0(self, "__iter__"); ok {
+		return res, err
+	}
+	if ObjectIsSequence(self) {
+		return NewIterator(self), nil
+	}
+	return nil, ExceptionNewf(TypeError, "'%s' object is not iterable", self.Type().Name)
+}

--- a/py/list.go
+++ b/py/list.go
@@ -186,7 +186,7 @@ func (l *List) M__bool__() (Object, error) {
 }
 
 func (l *List) M__iter__() (Object, error) {
-	return NewIterator(l.Items), nil
+	return NewIterator(Tuple(l.Items)), nil
 }
 
 func (l *List) M__getitem__(key Object) (Object, error) {
@@ -496,7 +496,11 @@ func SortInPlace(l *List, kwargs StringDict, funcName string) error {
 		reverse = False
 	}
 	// FIXME: requires the same bool-check like CPython (or better "|$Op" that doesn't panic on nil).
-	s := ptrSortable{&sortable{l, keyFunc, ObjectIsTrue(reverse), nil}}
+	ok, err := ObjectIsTrue(reverse)
+	if err != nil {
+		return err
+	}
+	s := ptrSortable{&sortable{l, keyFunc, ok, nil}}
 	sort.Stable(s)
 	return s.s.firstErr
 }

--- a/py/map.go
+++ b/py/map.go
@@ -1,0 +1,60 @@
+// Copyright 2023 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package py
+
+// A python Map object
+type Map struct {
+	iters Tuple
+	fun   Object
+}
+
+var MapType = NewTypeX("filter", `map(func, *iterables) --> map object
+
+Make an iterator that computes the function using arguments from
+each of the iterables.  Stops when the shortest iterable is exhausted.`,
+	MapTypeNew, nil)
+
+// Type of this object
+func (m *Map) Type() *Type {
+	return FilterType
+}
+
+// MapType
+func MapTypeNew(metatype *Type, args Tuple, kwargs StringDict) (res Object, err error) {
+	numargs := len(args)
+	if numargs < 2 {
+		return nil, ExceptionNewf(TypeError, "map() must have at least two arguments.")
+	}
+	iters := make(Tuple, numargs-1)
+	for i := 1; i < numargs; i++ {
+		iters[i-1], err = Iter(args[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Map{iters: iters, fun: args[0]}, nil
+}
+
+func (m *Map) M__iter__() (Object, error) {
+	return m, nil
+}
+
+func (m *Map) M__next__() (Object, error) {
+	numargs := len(m.iters)
+	argtuple := make(Tuple, numargs)
+
+	for i := 0; i < numargs; i++ {
+		val, err := Next(m.iters[i])
+		if err != nil {
+			return nil, err
+		}
+		argtuple[i] = val
+	}
+	return Call(m.fun, argtuple, nil)
+}
+
+// Check interface is satisfied
+var _ I__iter__ = (*Map)(nil)
+var _ I__next__ = (*Map)(nil)

--- a/py/tests/filter.py
+++ b/py/tests/filter.py
@@ -1,0 +1,65 @@
+# test_builtin.py:BuiltinTest.test_filter()
+from libtest import assertRaises
+
+doc="filter"
+class T0:
+    def __bool__(self):
+        return True
+class T1:
+    def __len__(self):
+        return 1
+class T2:
+    def __bool__(self):
+        return False
+class T3:
+    pass
+t0, t1, t2, t3 = T0(), T1(), T2(), T3()
+assert list(filter(None, [t0, t1, t2, t3])) == [t0, t1, t3]
+assert list(filter(None, [1, [], 2, ''])) == [1, 2]
+
+class T3:
+    def __len__(self):
+        raise ValueError
+t3 = T3()
+assertRaises(ValueError, list, filter(None, [t3]))
+
+class Squares:
+    def __init__(self, max):
+        self.max = max
+        self.sofar = []
+
+    def __len__(self): return len(self.sofar)
+
+    def __getitem__(self, i):
+        if not 0 <= i < self.max: raise IndexError
+        n = len(self.sofar)
+        while n <= i:
+            self.sofar.append(n*n)
+            n += 1
+        return self.sofar[i]
+
+assert list(filter(lambda c: 'a' <= c <= 'z', 'Hello World')) == list('elloorld')
+assert list(filter(None, [1, 'hello', [], [3], '', None, 9, 0])) == [1, 'hello', [3], 9]
+assert list(filter(lambda x: x > 0, [1, -3, 9, 0, 2])) == [1, 9, 2]
+assert list(filter(None, Squares(10))) == [1, 4, 9, 16, 25, 36, 49, 64, 81]
+assert list(filter(lambda x: x%2, Squares(10))) == [1, 9, 25, 49, 81]
+def identity(item):
+    return 1
+filter(identity, Squares(5))
+assertRaises(TypeError, filter)
+class BadSeq(object):
+    def __getitem__(self, index):
+        if index<4:
+            return 42
+        raise ValueError
+assertRaises(ValueError, list, filter(lambda x: x, BadSeq()))
+def badfunc():
+    pass
+assertRaises(TypeError, list, filter(badfunc, range(5)))
+
+# test bltinmodule.c::filtertuple()
+assert list(filter(None, (1, 2))) == [1, 2]
+assert list(filter(lambda x: x>=3, (1, 2, 3, 4))) == [3, 4]
+assertRaises(TypeError, list, filter(42, (1, 2)))
+
+doc="finished"

--- a/py/tests/iter.py
+++ b/py/tests/iter.py
@@ -18,4 +18,16 @@ words1 = ['g', 'p', 'y', 't', 'h', 'o', 'n']
 words2 = list(iter(words1))
 for w1, w2 in zip(words1, words2):
     assert w1 == w2
+
+class SequenceClass:
+    def __init__(self, n):
+        self.n = n
+    def __getitem__(self, i):
+        if 0 <= i < self.n:
+            return i
+        else:
+            raise IndexError
+
+assert list(iter(SequenceClass(5))) == [0, 1, 2, 3, 4]
+
 doc="finished"

--- a/py/tests/map.py
+++ b/py/tests/map.py
@@ -1,0 +1,54 @@
+# test_builtin.py:BuiltinTest.test_map()
+from libtest import assertRaises
+
+doc="map"
+class Squares:
+    def __init__(self, max):
+        self.max = max
+        self.sofar = []
+
+    def __len__(self): return len(self.sofar)
+
+    def __getitem__(self, i):
+        if not 0 <= i < self.max: raise IndexError
+        n = len(self.sofar)
+        while n <= i:
+            self.sofar.append(n*n)
+            n += 1
+        return self.sofar[i]
+
+assert list(map(lambda x: x*x, range(1,4))) == [1, 4, 9]
+try:
+    from math import sqrt
+except ImportError:
+    def sqrt(x):
+        return pow(x, 0.5)
+assert list(map(lambda x: list(map(sqrt, x)), [[16, 4], [81, 9]])) == [[4.0, 2.0], [9.0, 3.0]]
+assert list(map(lambda x, y: x+y, [1,3,2], [9,1,4])) == [10, 4, 6]
+
+def plus(*v):
+    accu = 0
+    for i in v: accu = accu + i
+    return accu
+assert list(map(plus, [1, 3, 7])) == [1, 3, 7]
+assert list(map(plus, [1, 3, 7], [4, 9, 2])) == [1+4, 3+9, 7+2]
+assert list(map(plus, [1, 3, 7], [4, 9, 2], [1, 1, 0])) == [1+4+1, 3+9+1, 7+2+0]
+assert list(map(int, Squares(10))) == [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+def Max(a, b):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+assert list(map(Max, Squares(3), Squares(2))) == [0, 1]
+assertRaises(TypeError, map)
+assertRaises(TypeError, map, lambda x: x, 42)
+class BadSeq:
+    def __iter__(self):
+        raise ValueError
+        yield None
+assertRaises(ValueError, list, map(lambda x: x, BadSeq()))
+def badfunc(x):
+    raise RuntimeError
+assertRaises(RuntimeError, list, map(badfunc, range(5)))
+doc="finished"

--- a/py/type.go
+++ b/py/type.go
@@ -306,7 +306,7 @@ func (t *Type) NewTypeFlags(Name string, Doc string, New NewFunc, Init InitFunc,
 		Dict:       StringDict{},
 		Bases:      Tuple{t},
 	}
-	TypeDelayReady(t)
+	TypeDelayReady(tt)
 	return tt
 }
 

--- a/stdlib/builtin/builtin.go
+++ b/stdlib/builtin/builtin.go
@@ -292,7 +292,11 @@ func builtin_all(self, seq py.Object) (py.Object, error) {
 			}
 			return nil, err
 		}
-		if !py.ObjectIsTrue(item) {
+		ok, err := py.ObjectIsTrue(item)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
 			return py.False, nil
 		}
 	}
@@ -317,7 +321,11 @@ func builtin_any(self, seq py.Object) (py.Object, error) {
 			}
 			return nil, err
 		}
-		if py.ObjectIsTrue(item) {
+		ok, err := py.ObjectIsTrue(item)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
 			return py.True, nil
 		}
 	}

--- a/stdlib/builtin/builtin.go
+++ b/stdlib/builtin/builtin.go
@@ -77,9 +77,9 @@ func init() {
 		"complex":     py.ComplexType,
 		"dict":        py.StringDictType, // FIXME
 		"enumerate":   py.EnumerateType,
-		// "filter":         py.FilterType,
-		"float":     py.FloatType,
-		"frozenset": py.FrozenSetType,
+		"filter":      py.FilterType,
+		"float":       py.FloatType,
+		"frozenset":   py.FrozenSetType,
 		// "property":       py.PropertyType,
 		"int":  py.IntType, // FIXME LongType?
 		"list": py.ListType,

--- a/stdlib/builtin/builtin.go
+++ b/stdlib/builtin/builtin.go
@@ -81,9 +81,9 @@ func init() {
 		"float":       py.FloatType,
 		"frozenset":   py.FrozenSetType,
 		// "property":       py.PropertyType,
-		"int":  py.IntType, // FIXME LongType?
-		"list": py.ListType,
-		// "map":            py.MapType,
+		"int":    py.IntType, // FIXME LongType?
+		"list":   py.ListType,
+		"map":    py.MapType,
 		"object": py.ObjectType,
 		"range":  py.RangeType,
 		// "reversed":       py.ReversedType,

--- a/stdlib/builtin/tests/builtin.py
+++ b/stdlib/builtin/tests/builtin.py
@@ -275,6 +275,12 @@ except ValueError:
     ok = True
 assert ok, "ValueError not raised"
 
+doc="oct"
+assert oct(0) == '0o0'
+assert oct(100) == '0o144'
+assert oct(-100) == '-0o144'
+assertRaises(TypeError, oct, ())
+
 doc="ord"
 assert 65 == ord("A")
 assert 163 == ord("£")


### PR DESCRIPTION
## [all: support filter builtin feature and fix iterable object](https://github.com/go-python/gpython/commit/80d61cff6b58f041d7d88486133beb5cd9cfeebf)

Python-3.4.9/Doc/c-api/iterator.rst
> Python provides two general-purpose iterator objects.  The first, a sequence
iterator, works with an arbitrary sequence supporting the :meth:`__getitem__`
method.  The second works with a callable object and a sentinel value, calling
the callable for each item in the sequence, and ending the iteration when the
sentinel value is returned.

`Python-3.4.9/Lib/test/test_builtin.py`
```python
class Squares:

    def __init__(self, max):
        self.max = max
        self.sofar = []

    def __len__(self): return len(self.sofar)

    def __getitem__(self, i):
        if not 0 <= i < self.max: raise IndexError
        n = len(self.sofar)
        while n <= i:
            self.sofar.append(n*n)
            n += 1
        return self.sofar[i]
```
In CPython, `Squares (5)` is an iterable object, and to support this type of iterable object, I made modifications to `Iterator. go`

---

Iterator. go
```go
type Iterator struct {
	Pos int
	Seq Object
}
// ...
func (it *Iterator) M__next__() (res Object, err error) {
	if tuple, ok := it.Seq.(Tuple); ok {
		if it.Pos >= len(tuple) {
			return nil, StopIteration
		}
		res = tuple[it.Pos]
		it.Pos++
		return res, nil
	}
	index := Int(it.Pos)
	if I, ok := it.Seq.(I__getitem__); ok {
		res, err = I.M__getitem__(index)
	} else if res, ok, err = TypeCall1(it.Seq, "__getitem__", index); !ok {
		return nil, ExceptionNewf(TypeError, "'%s' object is not iterable", it.Type().Name)
	}
	if err != nil {
		if IsException(IndexError, err) {
			return nil, StopIteration
		}
		return nil, err
	}
	it.Pos++
	return res, nil
}
```
Corresponding CPython code  
`Python-3.4.9/Objects/iterobject.c`
```c
static PyObject *
iter_iternext(PyObject *iterator)
{
    seqiterobject *it;
    PyObject *seq;
    PyObject *result;

    assert(PySeqIter_Check(iterator));
    it = (seqiterobject *)iterator;
    seq = it->it_seq;
    if (seq == NULL)
        return NULL;
    if (it->it_index == PY_SSIZE_T_MAX) {
        PyErr_SetString(PyExc_OverflowError,
                        "iter index too large");
        return NULL;
    }

    result = PySequence_GetItem(seq, it->it_index);
    if (result != NULL) {
        it->it_index++;
        return result;
    }
    if (PyErr_ExceptionMatches(PyExc_IndexError) ||
        PyErr_ExceptionMatches(PyExc_StopIteration))
    {
        PyErr_Clear();
        Py_DECREF(seq);
        it->it_seq = NULL;
    }
    return NULL;
}
```
---
and `Iter()`
```go
func Iter(self Object) (res Object, err error) {
	if I, ok := self.(I__iter__); ok {
		return I.M__iter__()
	} else if res, ok, err = TypeCall0(self, "__iter__"); ok {
		return res, err
	}
	if ObjectIsSequence(self) {
		return NewIterator(self), nil
	}
	return nil, ExceptionNewf(TypeError, "'%s' object is not iterable", self.Type().Name)
}
```
Corresponding CPython code  
`Python-3.4.9/Objects/abstract.c`
```c
PyObject *
PyObject_GetIter(PyObject *o)
{
    PyTypeObject *t = o->ob_type;
    getiterfunc f = NULL;
    f = t->tp_iter;
    if (f == NULL) {
        if (PySequence_Check(o))
            return PySeqIter_New(o);
        return type_error("'%.200s' object is not iterable", o);
    }
    else {
        PyObject *res = (*f)(o);
        if (res != NULL && !PyIter_Check(res)) {
            PyErr_Format(PyExc_TypeError,
                         "iter() returned non-iterator "
                         "of type '%.100s'",
                         res->ob_type->tp_name);
            Py_DECREF(res);
            res = NULL;
        }
        return res;
    }
}
```

Finally, `filter` and `map` methods were fully implemented

`py/tests/filter.py` is a copy of `Python-3.4.9/Lib/test/test_builtin.py:BuiltinTest.test_filter()`
and
`py/tests/map.py` is a copy of `Python-3.4.9/Lib/test/test_builtin.py:BuiltinTest.test_map()`

## [builtin: Implement oct and optimise hex](https://github.com/go-python/gpython/commit/aa3e6b18adf4981ebb08c7dacb380070343bea79)

Through benchmark testing, the speed of `hex` has indeed been improved  

My English is not very good, so forgive me for not providing sufficient explanations. Welcome to ask questions here