### PR TITLE
Fixed WASM compatibility by avoiding panic due to absence of `os.Executable()`

### DIFF
--- a/stdlib/sys/sys.go
+++ b/stdlib/sys/sys.go
@@ -19,6 +19,7 @@ package sys
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/go-python/gpython/py"
 )
@@ -659,7 +660,14 @@ func init() {
 
 	executable, err := os.Executable()
 	if err != nil {
-		panic(err)
+		switch runtime.GOOS {
+		case "js", "wasip1":
+			// These platforms don't implement os.Executable (at least as of Go
+			// 1.21), see https://github.com/tailscale/tailscale/pull/8325
+			executable = "gpython"
+		default:
+			panic(err)
+		}
 	}
 
 	globals := py.StringDict{


### PR DESCRIPTION
 `os.Executable()` is not implemented in "js" and "wasip1" targets in current Golang versions, so WASM builds encounter `Executable not implemented for js` errors in runtime.

This fix is borrowed from Brad's https://github.com/tailscale/tailscale/pull/8325 .
