### PR TITLE
py: fix import on Windows

### DIFF
--- a/py/import.go
+++ b/py/import.go
@@ -7,7 +7,7 @@
 package py
 
 import (
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -101,14 +101,14 @@ func ImportModuleLevelObject(ctx Context, name string, globals, locals StringDic
 
 	// Convert import's dot separators into path seps
 	parts := strings.Split(name, ".")
-	srcPathname := path.Join(parts...)
+	srcPathname := filepath.Join(parts...)
 
 	opts := CompileOpts{
 		UseSysPaths: true,
 	}
 
 	if fromFile, ok := globals["__file__"]; ok {
-		opts.CurDir = path.Dir(string(fromFile.(String)))
+		opts.CurDir = filepath.Dir(string(fromFile.(String)))
 	}
 
 	module, err := RunFile(ctx, srcPathname, opts, name)


### PR DESCRIPTION
Currently gpython can't handle import on Windows because it's using `path` to handle file paths, which only support OSes which use `/` as path separator:

```
PS C:\Users\xxxxx\Source\gpython> go run . py\tests\string.py
Traceback (most recent call last):
  File "C:\\Users\\xxxxx\\Source\\gpython/py\\tests\\string.py", line 5, in <module>
FileNotFoundError: 'Failed to resolve "libtest"'
exit status 1
```

Using `path/filepath` can fix it.