### PR TITLE
py: fix exception repr

### DIFF
--- a/py/exception.go
+++ b/py/exception.go
@@ -368,9 +368,16 @@ func (e *Exception) M__str__() (Object, error) {
 }
 
 func (e *Exception) M__repr__() (Object, error) {
-	msg := e.Args.(Tuple)[0].(String)
 	typ := e.Base.Name
-	return String(fmt.Sprintf("%s(%q)", typ, string(msg))), nil
+	args := e.Args.(Tuple)
+	if len(args) == 0 {
+		return String(fmt.Sprintf("%s()", typ)), nil
+	}
+	msg, err := args.M__repr__()
+	if err != nil {
+		return nil, err
+	}
+	return String(fmt.Sprintf("%s%s", typ, string(msg.(String)))), nil
 }
 
 // Check Interfaces

--- a/vm/tests/exceptions.py
+++ b/vm/tests/exceptions.py
@@ -165,4 +165,10 @@ except ValueError:
     ok = True
 assert ok, "ValueError not raised"
 
+doc = "exception repr"
+repr(ValueError()) == "ValueError()"
+repr(ValueError(1)) == "ValueError(1)"
+repr(ValueError(1, 2, 3)) == "ValueError(1, 2, 3)"
+repr(ValueError("failed")) == 'ValueError("failed")'
+
 doc = "finished"


### PR DESCRIPTION
Support create `Exception` instance with multiple non-str arguments.