### PR TITLE
all: handle SystemExit

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,36 @@ func xmain(args []string) {
 	} else {
 		_, err := py.RunFile(ctx, args[0], py.CompileOpts{}, nil)
 		if err != nil {
+			if py.IsException(py.SystemExit, err) {
+				args := err.(py.ExceptionInfo).Value.(*py.Exception).Args.(py.Tuple)
+				if len(args) == 0 {
+					os.Exit(0)
+				} else if len(args) == 1 {
+					if code, ok := args[0].(py.Int); ok {
+						c, err := code.GoInt()
+						if err != nil {
+							fmt.Fprintln(os.Stderr, err)
+							os.Exit(1)
+						}
+						os.Exit(c)
+					}
+					msg, err := py.ReprAsString(args[0])
+					if err != nil {
+						fmt.Fprintln(os.Stderr, err)
+					} else {
+						fmt.Fprintln(os.Stderr, msg)
+					}
+					os.Exit(1)
+				} else {
+					msg, err := py.ReprAsString(args)
+					if err != nil {
+						fmt.Fprintln(os.Stderr, err)
+					} else {
+						fmt.Fprintln(os.Stderr, msg)
+					}
+					os.Exit(1)
+				}
+			}
 			py.TracebackDump(err)
 			os.Exit(1)
 		}

--- a/repl/cli/cli.go
+++ b/repl/cli/cli.go
@@ -117,7 +117,7 @@ func (rl *readline) Print(out string) {
 }
 
 // RunREPL starts the REPL loop
-func RunREPL(replCtx *repl.REPL) {
+func RunREPL(replCtx *repl.REPL) error {
 	if replCtx == nil {
 		replCtx = repl.New(nil)
 	}
@@ -144,6 +144,10 @@ func RunREPL(replCtx *repl.REPL) {
 		if line != "" {
 			rl.AppendHistory(line)
 		}
-		rl.repl.Run(line)
+		err = rl.repl.Run(line)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/stdlib/sys/sys.go
+++ b/stdlib/sys/sys.go
@@ -133,7 +133,11 @@ func sys_exit(self py.Object, args py.Tuple) (py.Object, error) {
 		return nil, err
 	}
 	// Raise SystemExit so callers may catch it or clean up.
-	return py.ExceptionNew(py.SystemExit, args, nil)
+	exc, err := py.ExceptionNew(py.SystemExit, args, nil)
+	if err != nil {
+		return nil, err
+	}
+	return nil, exc.(*py.Exception)
 }
 
 const getdefaultencoding_doc = `getdefaultencoding() -> string


### PR DESCRIPTION
Currently `raise SystemExit()` or calling `sys.exit()` is not handled correctly. The interpreter will crash because `Exception.__repr__` can't handle `SystemExit`, but #242 will fix this. So we should handle the `SystemExit` and exit the interpreter.