### PR TITLE
pytest: ensure expected string's line sep is \n

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -48,6 +48,7 @@ func TestGPython(t *testing.T) {
 	}
 
 	want, err := os.ReadFile(fname)
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
 	if err != nil {
 		t.Fatalf("could not read golden file: %+v", err)
 	}

--- a/pytest/pytest.go
+++ b/pytest/pytest.go
@@ -273,6 +273,7 @@ func (task *Task) run() error {
 		return fmt.Errorf("could not read golden output %q: %w", task.GoldFile, err)
 	}
 
+	want = bytes.ReplaceAll(want, []byte("\r\n"), []byte("\n"))
 	diff := cmp.Diff(string(want), string(got))
 	if !bytes.Equal(got, want) {
 		out := fileBase + ".txt"


### PR DESCRIPTION
Some tests failed on my Windows machine, and I found that some excepted output are using "\r\n" as line separator. The tests passed on Github Actions's Windows environment, so I guess git have some configs that will convert the line separator to the default one in current OS ("\r\n" on Windows).

So I think we still need to fix it, because someone else may have this git config too.